### PR TITLE
fix: remove reckless assertion

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assert = require('assert');
 const rds = require('ali-rds');
 
 let count = 0;
@@ -10,9 +9,6 @@ module.exports = app => {
 };
 
 function createOneClient(config, app) {
-  assert(config.host && config.port && config.user && config.database,
-    `[egg-mysql] 'host: ${config.host}', 'port: ${config.port}', 'user: ${config.user}', 'database: ${config.database}' are required on config`);
-
   app.coreLogger.info('[egg-mysql] connecting %s@%s:%s/%s',
     config.user, config.host, config.port, config.database);
   const client = rds(config);


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

No effect.
##### Description of change
<!-- Provide a description of the change below this comment. -->

This lib couldn't be used when connecting MySQL with the socket instead of host and password if it has a reckless assertion.
